### PR TITLE
Add key expiry timeouts

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,13 +11,21 @@ before_install:
     - docker-compose
       -f config/docker-compose.base.yaml
       -f config/docker-compose.dev.yaml
-      -p api
+      -p kansa
       up --build -d
     - sleep 10  # allow time for postgres db init
     - cd integration-tests
 
 after_failure:
-    - docker-compose logs
+    - docker-compose
+      -f ../config/docker-compose.base.yaml
+      -f ../config/docker-compose.dev.yaml
+      -p kansa
+      logs
 
 after_script:
-    - docker-compose down
+    - docker-compose
+      -f ../config/docker-compose.base.yaml
+      -f ../config/docker-compose.dev.yaml
+      -p kansa
+      down

--- a/Makefile
+++ b/Makefile
@@ -18,8 +18,12 @@ update-%:
 stop:
 	$(DC) stop
 
-test: | integration-tests/node_modules
+test-reset:
+	docker exec kansa_postgres_1 psql api kansa -c "SELECT reset_test_users();"
+
+test: test-reset | integration-tests/node_modules
 	cd integration-tests && npm test
+	@${MAKE} test-reset
 
 integration-tests/node_modules:
 	cd integration-tests && npm install

--- a/config/database/dev-people.sql
+++ b/config/database/dev-people.sql
@@ -11,6 +11,7 @@ INSERT INTO People (legal_name, email, membership, member_number)
             ('Member Admin', 'member-admin@example.com', 'NonMember', NULL),
             ('Site Selection', 'site-select@example.com', 'NonMember', NULL),
             ('Hugo Admin', 'hugo-admin@example.com', 'NonMember', NULL),
+            ('Expired Login', 'expired@example.com', 'NonMember', NULL),
             ('First Member', 'member@example.com', 'FirstWorldcon', 2),
             ('Fan Parent', 'family@example.com', 'Adult', 3),
             ('Fan Child', 'family@example.com', 'Child', 4),
@@ -21,16 +22,26 @@ INSERT INTO People (legal_name, email, membership, member_number)
             ('Fan Helper', 'helper@example.com', 'Helper', 9),
             ('Fan Nominator', 'nominator@example.com', 'HugoNominator', NULL);
 
-INSERT INTO Keys
-     VALUES ('admin@example.com', 'key'),
-            ('member-admin@example.com', 'key'),
-            ('site-select@example.com', 'key'),
-            ('hugo-admin@example.com', 'key'),
-            ('family@example.com', 'key'),
-            ('member@example.com', 'key'),
-            ('nominator@example.com', 'key'),
-            ('trader@example.com', 'key'),
-            ('helper@example.com', 'key'),
-            ('supporter@example.com', 'key');
+INSERT INTO Keys (email, key, expires)
+     VALUES ('admin@example.com', 'key', NULL),
+            ('member-admin@example.com', 'key', NULL),
+            ('site-select@example.com', 'key', NULL),
+            ('hugo-admin@example.com', 'key', NULL),
+            ('expired@example.com', 'key', '2017-08-13'),
+            ('family@example.com', 'key', NULL),
+            ('member@example.com', 'key', NULL),
+            ('nominator@example.com', 'key', NULL),
+            ('trader@example.com', 'key', NULL),
+            ('helper@example.com', 'key', NULL),
+            ('supporter@example.com', 'key', NULL);
 
 ALTER SEQUENCE member_number_seq RESTART WITH 42;
+
+-- The admin & expired users are used by integration tests, and are expected
+-- to initially have these key values.
+CREATE FUNCTION reset_test_users() RETURNS void AS $$
+BEGIN
+  UPDATE keys SET key='key', expires=NULL WHERE email='admin@example.com';
+  UPDATE keys SET key='key', expires='2017-08-13' WHERE email='expired@example.com';
+END;
+$$ LANGUAGE plpgsql;

--- a/config/database/fake-people.sql
+++ b/config/database/fake-people.sql
@@ -23,7 +23,7 @@ ALTER TABLE kansa.people ADD COLUMN hugo_nominator bool;
 ALTER TABLE kansa.people ADD COLUMN hugo_voter bool;
 COPY kansa.people (id, last_modified, membership, member_number, legal_name, public_first_name, public_last_name, email, city, state, country, badge_name, badge_subtitle, hugo_nominator, hugo_voter, paper_pubs) FROM stdin;
 15	2018-07-29 18:14:07.698028+00	FirstWorldcon	43	Factual Blob	Fake (Factual)	Blob	fblog@fblobsblog.com	Fact City	Data Central	Blobitania	\N	\N	\N	\N	\N
-14	2018-07-29 18:14:07.701524+00	Supporter	42	Samuel Vimes	\N	\N	s.vimes@gmial.ocm	Ankh-Morpork	\N	The Disc	\N	\N	\N	\N	{"name": "Samuel Vimes", "address": "11, Broadstreet\\r\\nAnkh-Morpork", "country": "Ankh-Morpork"}
+661	2018-07-29 18:14:07.701524+00	Supporter	42	Samuel Vimes	\N	\N	s.vimes@gmial.ocm	Ankh-Morpork	\N	The Disc	\N	\N	\N	\N	{"name": "Samuel Vimes", "address": "11, Broadstreet\\r\\nAnkh-Morpork", "country": "Ankh-Morpork"}
 16	2018-07-29 18:14:07.762761+00	FirstWorldcon	44	Æthelwine B. Clobberfeld	Æthelwine	Clobberfeld	abc@cba.nr	Yaren	Yaren District	Nauru	\N	\N	\N	\N	{"name": "Æthelwine B. Clobberfeld", "address": "42 Yaren Drive\\r\\nYaren", "country": "Nauru"}
 17	2018-07-29 18:14:07.804774+00	Adult	45	Polly Amorous	Polly	Amorous	Allthelove@manymoresomuch.fi	Helsinki	Helsinki	Finland	\N	\N	\N	\N	{"name": "Polly", "address": "Amorous", "country": "Helsinki"}
 18	2018-07-29 18:14:07.831094+00	Adult	46	Jorma Mörönen	\N	\N	jorma@moronen.com	Paris	\N	France	\N	\N	\N	\N	\N
@@ -680,8 +680,8 @@ ALTER TABLE kansa.people DROP COLUMN hugo_voter;
 
 COPY kansa.log (id, "timestamp", client_ip, client_ua, author, subject, action, parameters, description) FROM stdin;
 1	2018-07-29 18:13:33.179618+00	::ffff:172.23.0.10	node-fetch/1.0 (+https://github.com/bitinn/node-fetch)	admin@example.com	\N	GET /login	{"email": "admin@example.com"}	Login
-2	2016-08-04 12:29:02+00	::ffff:172.23.0.10	node-fetch/1.0 (+https://github.com/bitinn/node-fetch)	admin@example.com	14	POST /people	{"city": "Ankh-Morpork", "email": "s.vimes@gmial.ocm", "voter": false, "country": "The Disc", "timestamp": "8/4/2016 12:29:02 UTC", "legal_name": "Samuel Vimes", "membership": "Supporter"}	Add new person
-3	2018-07-29 18:14:07.701524+00	::ffff:172.23.0.10	node-fetch/1.0 (+https://github.com/bitinn/node-fetch)	admin@example.com	\N	POST /people/14/upgrade	{"timestamp": "undefined UTC", "paper_pubs": {"name": "Samuel Vimes", "address": "11, Broadstreet\\r\\nAnkh-Morpork", "country": "Ankh-Morpork"}}	Add paper pubs
+2	2016-08-04 12:29:02+00	::ffff:172.23.0.10	node-fetch/1.0 (+https://github.com/bitinn/node-fetch)	admin@example.com	661	POST /people	{"city": "Ankh-Morpork", "email": "s.vimes@gmial.ocm", "voter": false, "country": "The Disc", "timestamp": "8/4/2016 12:29:02 UTC", "legal_name": "Samuel Vimes", "membership": "Supporter"}	Add new person
+3	2018-07-29 18:14:07.701524+00	::ffff:172.23.0.10	node-fetch/1.0 (+https://github.com/bitinn/node-fetch)	admin@example.com	\N	POST /people/661/upgrade	{"timestamp": "undefined UTC", "paper_pubs": {"name": "Samuel Vimes", "address": "11, Broadstreet\\r\\nAnkh-Morpork", "country": "Ankh-Morpork"}}	Add paper pubs
 4	2016-08-04 12:30:50+00	::ffff:172.23.0.10	node-fetch/1.0 (+https://github.com/bitinn/node-fetch)	admin@example.com	15	POST /people	{"city": "Fact City", "email": "fblog@fblobsblog.com", "state": "Data Central", "country": "Blobitania", "timestamp": "8/4/2016 12:30:50 UTC", "legal_name": "Factual Blob", "membership": "FirstWorldcon", "public_last_name": "Blob", "public_first_name": "Fake (Factual)"}	Add new person
 5	2016-08-04 12:31:26+00	::ffff:172.23.0.10	node-fetch/1.0 (+https://github.com/bitinn/node-fetch)	admin@example.com	16	POST /people	{"city": "Yaren", "email": "abc@cba.nr", "state": "Yaren District", "country": "Nauru", "timestamp": "8/4/2016 12:31:26 UTC", "legal_name": "Æthelwine B. Clobberfeld", "membership": "FirstWorldcon", "public_last_name": "Clobberfeld", "public_first_name": "Æthelwine"}	Add new person
 6	2018-07-29 18:14:07.762761+00	::ffff:172.23.0.10	node-fetch/1.0 (+https://github.com/bitinn/node-fetch)	admin@example.com	\N	POST /people/16/upgrade	{"timestamp": "undefined UTC", "paper_pubs": {"name": "Æthelwine B. Clobberfeld", "address": "42 Yaren Drive\\r\\nYaren", "country": "Nauru"}}	Add paper pubs
@@ -1658,7 +1658,7 @@ SELECT pg_catalog.setval('kansa.member_number_seq', 688, true);
 -- Name: people_id_seq; Type: SEQUENCE SET; Schema: kansa; Owner: kansa
 --
 
-SELECT pg_catalog.setval('kansa.people_id_seq', 660, true);
+SELECT pg_catalog.setval('kansa.people_id_seq', 661, true);
 
 --
 -- PostgreSQL database dump complete

--- a/config/kansa.yaml
+++ b/config/kansa.yaml
@@ -11,8 +11,14 @@ name: Worldcon 75
 paid_paper_pubs: false
 
 # Authentication configuration. Duration values should use suffixes to indicate
-# units, e.g. "1d 3h" or "4w". To disable a timeout, use a null value.
+# units, e.g. "1d 3h" or "4w".
 auth:
+
+  # If an expired key is used for login, the key is reset and automatically
+  # sent by email. Admin users are those with any administrative privileges.
+  key_timeout:
+    normal: 1y
+    admin: 5d
 
   # After session timeout, a user is redirected to the sign-in page at their
   # next request.

--- a/config/kansa.yaml
+++ b/config/kansa.yaml
@@ -9,3 +9,11 @@ name: Worldcon 75
 # action that requires payment. If false, paper pubs may be added without any
 # cost.
 paid_paper_pubs: false
+
+# Authentication configuration. Duration values should use suffixes to indicate
+# units, e.g. "1d 3h" or "4w". To disable a timeout, use a null value.
+auth:
+
+  # After session timeout, a user is redirected to the sign-in page at their
+  # next request.
+  session_timeout: 5d

--- a/docs/index.md
+++ b/docs/index.md
@@ -125,7 +125,10 @@ included in the login link as the value of the `next` query parameter.
 ### `GET/POST login`
 - Parameters: `email`, `key`
 
-If the pair `key`, `email` matches known values, create a new session object
+Fails with HTTP status `400` for missing input values, `401` for incorrect
+`email`/`key` combinations, and `403` for expired `key` (which triggers a key
+reset and sends an email with an updated login link). Creates a new session
+object for valid credentials.
 
 #### Response
 ```

--- a/integration-tests/test/login.spec.js
+++ b/integration-tests/test/login.spec.js
@@ -91,7 +91,7 @@ describe('Login', () => {
         .end(done);
     });
 
-    it('gets unauthorized from /api/usr', (done) => {
+    it('gets unauthorized from /api/user', (done) => {
       unlogged.get('/api/user')
         .expect(401, { status: 'unauthorized' })
         .end(done)
@@ -106,10 +106,26 @@ describe('Login', () => {
         .end(done);
     });
 
-    it('gets unauthorized from /api/usr', (done) => {
+    it('gets unauthorized from /api/user', (done) => {
       unlogged.get('/api/user')
-        .expect(401,{status:'unauthorized'})
+        .expect(401, { status: 'unauthorized' })
         .end(done);
+    });
+  });
+
+  context('Login with expired key', () => {
+    it('gets 403 response', (done) => {
+      const email = 'expired@example.com'
+      unlogged.get('/api/login')
+        .query({ email, key: 'key' })
+        .expect(403, { email, status: 'expired' })
+        .end(done)
+    });
+
+    it('gets unauthorized from /api/user', (done) => {
+      unlogged.get('/api/user')
+        .expect(401, { status: 'unauthorized' })
+        .end(done)
     });
   });
 });

--- a/kansa/app.js
+++ b/kansa/app.js
@@ -119,7 +119,7 @@ if (corsOrigins) app.use(cors({
   origin: corsOrigins.split(/[ ,]+/)
 }));
 app.use(session({
-  cookie: { maxAge: 30 * 24 * 60 * 60 * 1000 },  // 30 days
+  cookie: { maxAge: config.auth.session_timeout },
   name: config.id,
   resave: false,
   saveUninitialized: false,

--- a/kansa/lib/config.js
+++ b/kansa/lib/config.js
@@ -1,4 +1,5 @@
 const fs = require('fs')
+const timestring = require('timestring')
 const YAML = require('yaml').default
 
 const src = fs.readFileSync('/kansa.yaml', 'utf8')
@@ -7,31 +8,56 @@ const config = YAML.parse(src)
 const shape = {
   id: /^\w+$/,
   name: 'string',
-  paid_paper_pubs: 'boolean'
+  paid_paper_pubs: 'boolean',
+  auth: {
+    session_timeout: 'duration'
+  }
 }
 
-function checkConfig(key, config, shape) {
+const getIn = (config, path) => {
+  let value = config
+  path.forEach(p => { value = value[p] })
+  return value
+}
+
+function parseConfig(config, path, shape) {
+  const key = path.join('.')
+  const value = getIn(config, path)
   if (shape instanceof RegExp) {
-    if (typeof config !== 'string') {
-      throw new Error(`Expected string value for '${key}', but found ${typeof config}`)
+    if (typeof value !== 'string') {
+      throw new Error(`Expected string value for '${key}', but found ${typeof value}`)
     }
-    if (!shape.test(config)) {
+    if (!shape.test(value)) {
       throw new Error(`Expected value for '${key}' to match regular expression ${shape}`)
     }
   } else if (typeof shape === 'object') {
-    if (typeof config !== 'object') {
+    if (typeof value !== 'object') {
       throw new Error(key
-        ? `Expected object value for '${key}', but found ${typeof config}`
-        : `Expected configuration object, but found ${typeof config}`
+        ? `Expected object value for '${key}', but found ${typeof value}`
+        : `Expected configuration object, but found ${typeof value}`
       )
     }
     Object.keys(shape).forEach(k => {
-      checkConfig(key ? `${key}.${k}` : k, config[k], shape[k])
+      parseConfig(config, path.concat(k), shape[k])
     })
-  } else if (typeof config !== shape) {
-    throw new Error(`Expected ${shape} value for '${key}', but found ${typeof config}`)
+  } else if (shape === 'duration') {
+    if (typeof value !== 'string') {
+      throw new Error(`Expected string duration value for '${key}', but found ${typeof value}`)
+    }
+    const duration = timestring(value, 'ms')
+    if (duration === 0) {
+      throw new Error(/\d/.test(value)
+        ? `Duration suffix not recognised for '${key}'`
+        : `Expected positive duration value for '${key}'`
+      )
+    }
+    const k = path.pop()
+    const parent = getIn(config, path)
+    parent[k] = duration
+  } else if (typeof value !== shape) {
+    throw new Error(`Expected ${shape} value for '${key}', but found ${typeof value}`)
   }
 }
-checkConfig('', config, shape)
+parseConfig(config, [], shape)
 
 module.exports = config

--- a/kansa/lib/config.js
+++ b/kansa/lib/config.js
@@ -10,6 +10,10 @@ const shape = {
   name: 'string',
   paid_paper_pubs: 'boolean',
   auth: {
+    key_timeout: {
+      admin: 'duration',
+      normal: 'duration'
+    },
     session_timeout: 'duration'
   }
 }

--- a/kansa/lib/errors.js
+++ b/kansa/lib/errors.js
@@ -14,6 +14,4 @@ function InputError(message = 'Input error') {
 }
 InputError.prototype = new Error;
 
-const isNoDataError = ({ name, message }) => name === 'QueryResultError' && message === 'No data returned from the query.';
-
-module.exports = { AuthError, InputError, isNoDataError };
+module.exports = { AuthError, InputError };

--- a/kansa/lib/key.js
+++ b/kansa/lib/key.js
@@ -1,79 +1,117 @@
 const randomstring = require('randomstring');
 
-const { InputError, isNoDataError } = require('./errors');
+const config = require('./config')
+const { InputError } = require('./errors');
 const { mailTask, updateMailRecipient } = require('./mail')
 const LogEntry = require('./types/logentry');
 
-module.exports = { getKeyChecked, setKeyChecked, setKey, setAllKeys };
+module.exports = { refreshKey, resetExpiredKey, setKeyChecked, setKey, setAllKeys };
 
-function setKeyChecked(req, db, email, name) {
-  const data = { email, key: randomstring.generate(12), set: true };
-  return db.tx(tx => (
-    tx.none(`
-      INSERT INTO Keys (email, key) VALUES ($(email), $(key))
-      ON CONFLICT (email) DO UPDATE SET key = EXCLUDED.key`, data
-    ).then(() => {
-      if (!name) return 'Set access key';
-      return tx.none(`
-        INSERT INTO People (membership, legal_name, email)
-             VALUES ('NonMember', $1, $2)`, [name, email]
-      ).then(() => 'Create non-member account')
-    }).then(description => {
-      const log = new LogEntry(req, description);
-      log.author = email;
-      return tx.none(`INSERT INTO Log ${log.sqlValues}`, log);
-    }).then(() => updateMailRecipient(tx, email))
-  )).then(() => data);
+const getKeyMaxAge = (db, email) =>
+  db.one(`SELECT exists(SELECT 1 FROM admin.admins WHERE email = $1)`, email)
+    .then(({ exists: isAdmin }) => {
+      const type = isAdmin ? 'admin' : 'normal'
+      return config.auth.key_timeout[type] / 1000
+    })
+
+function refreshKey(req, db, email) {
+  return db.task(async ts => {
+    const maxAge = await getKeyMaxAge(ts, email)
+    const data = await ts.oneOrNone(`
+      UPDATE keys SET expires = now() + $(maxAge) * interval '1 second'
+      WHERE email = $(email)
+      RETURNING email, key`, { email, maxAge }
+    )
+    return data || setKeyChecked(req, ts, { email, maxAge })
+  })
 }
 
-function getKeyChecked(req, db, email) {
-  return db.task(ts => (
-    ts.oneOrNone(
-      'SELECT email, key FROM Keys WHERE email = $1', email
-    ).then(data => data || setKeyChecked(req, ts, email))
-  ))
+function resetExpiredKey(req, db, { email, path }) {
+  return db.tx(async tx => {
+    const key = randomstring.generate(12)
+    const maxAge = await getKeyMaxAge(tx, email)
+    await tx.none(`
+      UPDATE keys SET key=$(key),
+        expires = now() + $(maxAge) * interval '1 second'
+      WHERE email = $(email)`, { email, key, maxAge }
+    )
+    const log = new LogEntry(req, 'Reset access key');
+    log.author = email;
+    await tx.none(`INSERT INTO Log ${log.sqlValues}`, log);
+    await updateMailRecipient(tx, email)
+    await mailTask('kansa-set-key', { email, key, path })
+  })
+}
+
+function setKeyChecked(req, db, { email, maxAge, name }) {
+  return db.tx(async tx => {
+    if (!maxAge) maxAge = await getKeyMaxAge(tx, email)
+    const key = randomstring.generate(12)
+    await tx.none(`
+      INSERT INTO Keys (email, key, expires)
+      VALUES ($(email), $(key), now() + $(maxAge) * interval '1 second')
+      ON CONFLICT (email) DO
+        UPDATE SET key = EXCLUDED.key, expires = EXCLUDED.expires`,
+      { email, key, maxAge }
+    )
+    let description = 'Set access key'
+    if (name) {
+      await tx.none(`
+        INSERT INTO People (membership, legal_name, email)
+        VALUES ('NonMember', $1, $2)`, [name, email]
+      )
+      description = 'Create non-member account'
+    }
+    const log = new LogEntry(req, description);
+    log.author = email;
+    await tx.none(`INSERT INTO Log ${log.sqlValues}`, log);
+    await updateMailRecipient(tx, email)
+    return { email, key, maxAge, set: true }
+  })
 }
 
 function setKey(req, res, next) {
-  const { email, name, path, reset } = req.body;
-  if (!email) return next(new InputError('An email address is required for setting its key!'));
-  req.app.locals.db.task(ts => (
-    ts.many('SELECT email FROM People WHERE email ILIKE $1', email)
-      .then(data => reset
-        ? setKeyChecked(req, ts, data[0].email)
-        : getKeyChecked(req, ts, data[0].email))
-      .then(({ email, key, set }) => {
-        res.json({ status: 'success', email })
-        mailTask('kansa-set-key', { email, key, path, set })
-      })
-      .catch(error => {
-        if (!isNoDataError(error)) return next(error);
-        if (!name) return next(new InputError(
-          'Email address ' + JSON.stringify(email) + ' not found'
-        ));
-        setKeyChecked(req, ts, email, name)
-          .then(({ email, key }) => mailTask('kansa-create-account', { email, key, name, path }))
-          .then(() => res.json({ status: 'success', email }))
-          .catch(next)
-      })
-  ))
+  const { email: reqEmail, name, path, reset } = req.body;
+  if (!reqEmail) return next(new InputError('An email address is required for setting its key!'));
+  req.app.locals.db.task(async ts => {
+    const rows = await ts.any('SELECT email FROM People WHERE email ILIKE $1', reqEmail)
+    if (rows.length > 0) {
+      const { email } = rows[0]
+      const { key, set } = reset
+        ? await setKeyChecked(req, ts, { email })
+        : await refreshKey(req, ts, email)
+      await mailTask('kansa-set-key', { email, key, path, set })
+      res.json({ status: 'success', email })
+    } else {
+      if (!name) return next(new InputError(`Email address ${JSON.stringify(email)} not found`))
+      const { email, key } = await setKeyChecked(req, ts, { email: reqEmail, name })
+      await mailTask('kansa-create-account', { email, key, name, path })
+      res.json({ status: 'success', email })
+    }
+  }).catch(next)
 }
 
 function setAllKeys(req, res, next) {
-  req.app.locals.db.many(`
-       SELECT DISTINCT p.email
-         FROM People p
-    LEFT JOIN Keys k
-           ON p.email = k.email
-        WHERE k.email IS NULL`
-  )
-    .then(data => req.app.locals.db.tx(tx => tx.sequence((i) => data[i]
-      ? tx.any('INSERT INTO Keys (email, key) VALUES ($(email), $(key))', {
-          email: data[i].email,
-          key: randomstring.generate(12)
-        })
-      : undefined
-    )))
-    .then(() => res.status(200).json({ status: 'success' }))
-    .catch(err => next(err));
+  req.app.locals.db.tx(async tx => {
+    const data = await tx.any(`
+      SELECT DISTINCT p.email, a.email IS NOT NULL AS is_admin
+      FROM people p
+        LEFT JOIN keys k USING (email)
+        LEFT JOIN admin.admins a USING (email)
+      WHERE k.email IS NULL`
+    )
+    const kt = config.auth.key_timeout
+    await tx.sequence((i) => {
+      if (!data[i]) return undefined
+      const { email, is_admin } = data[i]
+      const key = randomstring.generate(12)
+      const maxAge = (is_admin ? kt.admin : kt.normal) / 1000
+      return tx.any(`
+        INSERT INTO Keys (email, key, expires)
+        VALUES ($(email), $(key), now() + $(maxAge) * interval '1 second')`,
+        { email, key, maxAge }
+      )
+    })
+    res.json({ status: 'success', count: data.length })
+  }).catch(next)
 }

--- a/kansa/lib/people.js
+++ b/kansa/lib/people.js
@@ -274,7 +274,7 @@ function updatePerson(req, res, next) {
           if (hugo_nominator || wsfs_member) {
             return prevKey
               ? { key: prevKey.key, name }
-              : setKeyChecked(req, dbTask, values.email)
+              : setKeyChecked(req, dbTask, { email: values.email })
                   .then(({ key }) => ({ key, name }));
           }
         }

--- a/kansa/lib/public.js
+++ b/kansa/lib/public.js
@@ -15,7 +15,7 @@ function getConfig(req, res, next) {
       rows.forEach(({ membership, ...props }) => {
         membershipTypes[membership] = props
       })
-      res.json(Object.assign({ membershipTypes }, config));
+      res.json(Object.assign({ membershipTypes }, config, { auth: undefined }));
     })
     .catch(next);
 }

--- a/kansa/package.json
+++ b/kansa/package.json
@@ -28,6 +28,7 @@
     "pg-promise": "^8.4.5",
     "randomstring": "^1.1.5",
     "stripe": "^6.3.0",
+    "timestring": "^5.0.1",
     "yaml": "^1.0.0-rc.7"
   }
 }

--- a/postgres/init/22-kansa-tables.sql
+++ b/postgres/init/22-kansa-tables.sql
@@ -31,7 +31,8 @@ CREATE TABLE IF NOT EXISTS People (
 
 CREATE TABLE IF NOT EXISTS Keys (
     email text PRIMARY KEY,
-    key text NOT NULL
+    key text NOT NULL,
+    expires timestamptz
 );
 
 CREATE TABLE IF NOT EXISTS Log (


### PR DESCRIPTION
This adds an `auth` section to `config/kansa.yaml`, which now defines the validity time of keys as well as sessions. By default, sessions are valid for five days and keys for one year. For admins, however, keys are only valid for five days.

When attempting login with an expired key, the key is automatically reset and emailed, and the server responds to the request with a `403` HTTP status and a body with `{ "status": "expired" }`.